### PR TITLE
[Fix] 현재까지 구현한 API 수정 실시 

### DIFF
--- a/server/src/main/java/com/team_60/Mocco/comment/dto/CommentDto.java
+++ b/server/src/main/java/com/team_60/Mocco/comment/dto/CommentDto.java
@@ -40,7 +40,7 @@ public class CommentDto {
         private String modifiedAt;
         private Comment.CommentStatus commentStatus;
         private MemberDto.SubResponse member;
-        private List<ReplyDto.Response> replies;
+        private List<ReplyDto.Response> replyList;
     }
 
 }

--- a/server/src/main/java/com/team_60/Mocco/comment/dto/CommentDto.java
+++ b/server/src/main/java/com/team_60/Mocco/comment/dto/CommentDto.java
@@ -1,5 +1,6 @@
 package com.team_60.Mocco.comment.dto;
 
+import com.team_60.Mocco.comment.entity.Comment;
 import com.team_60.Mocco.member.dto.MemberDto;
 import com.team_60.Mocco.reply.dto.ReplyDto;
 import lombok.AllArgsConstructor;
@@ -37,6 +38,7 @@ public class CommentDto {
         private String content;
         private String createdAt;
         private String modifiedAt;
+        private Comment.CommentStatus commentStatus;
         private MemberDto.SubResponse member;
         private List<ReplyDto.Response> replies;
     }

--- a/server/src/main/java/com/team_60/Mocco/comment/entity/Comment.java
+++ b/server/src/main/java/com/team_60/Mocco/comment/entity/Comment.java
@@ -29,7 +29,7 @@ public class Comment extends Auditable {
     @Column (length = 20, nullable = false)
     private CommentStatus commentStatus = CommentStatus.COMMENT_ACTIVE;
 
-    @ManyToOne(optional = false)
+    @ManyToOne
     @JoinColumn(name = "MEMBER_ID")
     private Member member;
 

--- a/server/src/main/java/com/team_60/Mocco/comment/mapper/CommentMapper.java
+++ b/server/src/main/java/com/team_60/Mocco/comment/mapper/CommentMapper.java
@@ -31,24 +31,7 @@ public interface CommentMapper {
 
     Comment commentPatchDtoToComment(CommentDto.Patch dto);
 
-    default CommentDto.Response commentToCommentResponseDto(Comment comment){
-        List<ReplyDto.Response> replies = comment.getReplyList()
-                .stream().map(reply -> ReplyMapper.replyToReplyResponseDto(reply))
-                .collect(Collectors.toList());
+    CommentDto.Response commentToCommentResponseDto(Comment comment);
 
-        return new CommentDto.Response(
-                comment.getCommentId(),
-                comment.getContent(),
-                comment.getCreatedAt(),
-                comment.getModifiedAt(),
-                MemberMapper.memberToMemberSubResponseDto(comment.getMember()),
-                replies
-        );
-    };
-
-    default List<CommentDto.Response> commentsToCommentResponseDtos(List<Comment> comments){
-        return comments.stream()
-                .map(comment -> commentToCommentResponseDto(comment))
-                .collect(Collectors.toList());
-    }
+    List<CommentDto.Response> commentsToCommentResponseDtos(List<Comment> comments);
 }

--- a/server/src/main/java/com/team_60/Mocco/comment/mapper/CommentMapper.java
+++ b/server/src/main/java/com/team_60/Mocco/comment/mapper/CommentMapper.java
@@ -3,14 +3,10 @@ package com.team_60.Mocco.comment.mapper;
 import com.team_60.Mocco.comment.dto.CommentDto;
 import com.team_60.Mocco.comment.entity.Comment;
 import com.team_60.Mocco.member.entity.Member;
-import com.team_60.Mocco.member.mapper.MemberMapper;
-import com.team_60.Mocco.reply.dto.ReplyDto;
-import com.team_60.Mocco.reply.mapper.ReplyMapper;
 import com.team_60.Mocco.study.entity.Study;
 import org.mapstruct.Mapper;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Mapper(componentModel = "spring")
 public interface CommentMapper {
@@ -30,8 +26,6 @@ public interface CommentMapper {
     }
 
     Comment commentPatchDtoToComment(CommentDto.Patch dto);
-
     CommentDto.Response commentToCommentResponseDto(Comment comment);
-
     List<CommentDto.Response> commentsToCommentResponseDtos(List<Comment> comments);
 }

--- a/server/src/main/java/com/team_60/Mocco/comment/service/CommentServiceImpl.java
+++ b/server/src/main/java/com/team_60/Mocco/comment/service/CommentServiceImpl.java
@@ -51,14 +51,14 @@ public class CommentServiceImpl implements CommentService{
 
         Optional.ofNullable(comment.getContent())
                 .ifPresent(content -> findComment.setContent(content));
-        return commentRepository.save(comment);
+        return commentRepository.save(findComment);
     }
 
     @Override
     public Comment deleteComment(long commentId) {
         Comment findComment = findVerifiedComment(commentId);
         findComment.setMember(null);
-        findComment.setContent(null);
+        findComment.setContent("");
         findComment.setCommentStatus(Comment.CommentStatus.COMMENT_DELETE);
         return commentRepository.save(findComment);
     }

--- a/server/src/main/java/com/team_60/Mocco/member/controller/MemberSubController.java
+++ b/server/src/main/java/com/team_60/Mocco/member/controller/MemberSubController.java
@@ -35,7 +35,7 @@ public class MemberSubController {
                 new SingleResponseDto(url), HttpStatus.OK);
     }
 
-    @PatchMapping("/{member-id}")
+    @PatchMapping("/password/{member-id}")
     public ResponseEntity patchPassword(@PathVariable("member-id") long memberId,
                                       @RequestBody MemberDto.PatchPassword requestBody){
 

--- a/server/src/main/java/com/team_60/Mocco/member/controller/MemberSubController.java
+++ b/server/src/main/java/com/team_60/Mocco/member/controller/MemberSubController.java
@@ -4,6 +4,8 @@ import com.team_60.Mocco.dto.SingleResponseDto;
 import com.team_60.Mocco.helper.upload.ImageUploadType;
 import com.team_60.Mocco.helper.upload.S3ImageUpload;
 import com.team_60.Mocco.member.dto.MemberDto;
+import com.team_60.Mocco.member.entity.Member;
+import com.team_60.Mocco.member.mapper.MemberMapper;
 import com.team_60.Mocco.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -19,6 +21,7 @@ import java.io.IOException;
 public class MemberSubController {
 
     private final S3ImageUpload imageUpload;
+    private final MemberMapper mapper;
     private final MemberService memberService;
 
     @PostMapping("/image")
@@ -30,6 +33,20 @@ public class MemberSubController {
 
         return new ResponseEntity(
                 new SingleResponseDto(url), HttpStatus.OK);
+    }
+
+    @PatchMapping("/{member-id}")
+    public ResponseEntity patchPassword(@PathVariable("member-id") long memberId,
+                                      @RequestBody MemberDto.PatchPassword requestBody){
+
+        Member member = new Member();
+        member.setMemberId(memberId);
+        member.setPassword(requestBody.getPassword());
+
+        Member updateMember = memberService.updatePassword(member);
+        MemberDto.Response response = mapper.memberToMemberResponseDto(updateMember);
+        return new ResponseEntity(
+                new SingleResponseDto(response), HttpStatus.OK);
     }
 
 

--- a/server/src/main/java/com/team_60/Mocco/member/dto/MemberDto.java
+++ b/server/src/main/java/com/team_60/Mocco/member/dto/MemberDto.java
@@ -27,7 +27,6 @@ public class MemberDto {
     @Setter
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Patch{
-        private String password;
         private String nickname;
         private String introduction;
         private String location;
@@ -35,6 +34,14 @@ public class MemberDto {
         private String githubRepository2;
         private String githubRepository3;
         private String profileImage;
+    }
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    @Setter
+    public static class PatchPassword{
+        private String password;
     }
 
     @AllArgsConstructor

--- a/server/src/main/java/com/team_60/Mocco/member/mapper/MemberMapper.java
+++ b/server/src/main/java/com/team_60/Mocco/member/mapper/MemberMapper.java
@@ -26,7 +26,6 @@ public interface MemberMapper {
 
     default Member memberPatchDtoToMember(MemberDto.Patch dto){
         Member member = new Member();
-        member.setPassword(dto.getPassword());
         member.setNickname(dto.getNickname());
         member.setMyInfo(memberPatchDtoToMyInfo(dto));
 

--- a/server/src/main/java/com/team_60/Mocco/member/mapper/MemberMapper.java
+++ b/server/src/main/java/com/team_60/Mocco/member/mapper/MemberMapper.java
@@ -71,7 +71,7 @@ public interface MemberMapper {
         );
     }
 
-    static MemberDto.SubResponse memberToMemberSubResponseDto(Member member){
+    default MemberDto.SubResponse memberToMemberSubResponseDto(Member member){
         return new MemberDto.SubResponse(
                 member.getMemberId(),
                 member.getNickname(),

--- a/server/src/main/java/com/team_60/Mocco/member/service/MemberService.java
+++ b/server/src/main/java/com/team_60/Mocco/member/service/MemberService.java
@@ -7,6 +7,7 @@ public interface MemberService {
     Member findMember(long memberId);
     Member createMember(Member member);
     Member updateMember(Member member);
+    Member updatePassword(Member member);
     void deleteMember(long memberId);
     Member findVerifiedMember(long memberId);
     void findMemberByNicknameExpectNull(String nickname);

--- a/server/src/main/java/com/team_60/Mocco/member/service/MemberServiceImpl.java
+++ b/server/src/main/java/com/team_60/Mocco/member/service/MemberServiceImpl.java
@@ -45,9 +45,6 @@ public class MemberServiceImpl implements MemberService{
             findMember.getMyInfo().setGithubRepository3(repositories[2]);
         }
 
-        Optional.ofNullable(member.getPassword())
-                .ifPresent(password ->
-                    findMember.setPassword(bCryptPasswordEncoder.encode(member.getPassword())));
         Optional.ofNullable(member.getNickname())
                 .ifPresent(nickName -> {
                     if (!nickName.equals(findMember.getNickname())){
@@ -62,6 +59,17 @@ public class MemberServiceImpl implements MemberService{
                 .ifPresent(introduction -> findMember.getMyInfo().setIntroduction(introduction));
         Optional.ofNullable(member.getMyInfo().getLocation())
                 .ifPresent(location -> findMember.getMyInfo().setLocation(location));
+
+        return memberRepository.save(findMember);
+    }
+
+    @Override
+    public Member updatePassword(Member member){
+        Member findMember = findVerifiedMember(member.getMemberId());
+
+        Optional.ofNullable(member.getPassword())
+                .ifPresent(password ->
+                        findMember.setPassword(bCryptPasswordEncoder.encode(member.getPassword())));
 
         return memberRepository.save(findMember);
     }

--- a/server/src/main/java/com/team_60/Mocco/proposal/mapper/ProposalMapper.java
+++ b/server/src/main/java/com/team_60/Mocco/proposal/mapper/ProposalMapper.java
@@ -13,20 +13,8 @@ import java.util.stream.Collectors;
 @Mapper(componentModel = "spring")
 public interface ProposalMapper {
 
-    default ProposalDto.Response proposalToProposalResponseDto(Proposal proposal){
-        return new ProposalDto.Response(
-                proposal.getProposalId(),
-                proposal.getContent(),
-                proposal.getCreatedAt(),
-                MemberMapper.memberToMemberSubResponseDto(proposal.getMember())
-        );
-    }
-
-    default List<ProposalDto.Response> proposalsToProposalResponseDtos(List<Proposal> proposals){
-        return proposals.stream()
-                .map(proposal -> proposalToProposalResponseDto(proposal))
-                .collect(Collectors.toList());
-    }
+    ProposalDto.Response proposalToProposalResponseDto(Proposal proposal);
+    List<ProposalDto.Response> proposalsToProposalResponseDtos(List<Proposal> proposals);
 
     default Proposal proposalPostDtoToProposal(ProposalDto.Post dto){
         Member member = new Member();

--- a/server/src/main/java/com/team_60/Mocco/proposal/service/ProposalServiceImpl.java
+++ b/server/src/main/java/com/team_60/Mocco/proposal/service/ProposalServiceImpl.java
@@ -61,6 +61,7 @@ public class ProposalServiceImpl implements ProposalService{
         findProposal.setProposalStatus(Proposal.ProposalStatus.PROPOSAL_ACCEPT);
         studyMemberService.createStudyMember(findProposal.getStudy(), findProposal.getMember());
 
+        // TODO 이거 왜 저장됨??
         return findProposal;
     }
 
@@ -70,7 +71,7 @@ public class ProposalServiceImpl implements ProposalService{
         checkProposalStatus(findProposal);
 
         findProposal.setProposalStatus(Proposal.ProposalStatus.PROPOSAL_DENIED);
-        return findProposal;
+        return proposalRepository.save(findProposal);
     }
 
     private Proposal findVerifiedProposal(long proposalId){

--- a/server/src/main/java/com/team_60/Mocco/reply/controller/ReplyController.java
+++ b/server/src/main/java/com/team_60/Mocco/reply/controller/ReplyController.java
@@ -22,7 +22,7 @@ public class ReplyController {
     public ResponseEntity getReply(@PathVariable("reply-id") long replyId){
 
         Reply findReply = replyService.findReply(replyId);
-        ReplyDto.Response response = ReplyMapper.replyToReplyResponseDto(findReply);
+        ReplyDto.Response response = mapper.replyToReplyResponseDto(findReply);
         return new ResponseEntity(
                 new SingleResponseDto(response), HttpStatus.OK);
     }
@@ -32,7 +32,7 @@ public class ReplyController {
 
         Reply reply = mapper.replyPostDtoToReply(requestBody);
         Reply postReply = replyService.createReply(reply);
-        ReplyDto.Response response = ReplyMapper.replyToReplyResponseDto(postReply);
+        ReplyDto.Response response = mapper.replyToReplyResponseDto(postReply);
         return new ResponseEntity(
                 new SingleResponseDto(response), HttpStatus.CREATED);
     }
@@ -44,7 +44,7 @@ public class ReplyController {
         Reply reply = mapper.replyPatchDtoToReply(requestBody);
         reply.setReplyId(replyId);
         Reply patchReply = replyService.updateReply(reply);
-        ReplyDto.Response response = ReplyMapper.replyToReplyResponseDto(patchReply);
+        ReplyDto.Response response = mapper.replyToReplyResponseDto(patchReply);
         return new ResponseEntity(
                 new SingleResponseDto(response), HttpStatus.OK);
     }
@@ -53,7 +53,7 @@ public class ReplyController {
     public ResponseEntity deleteReply(@PathVariable("reply-id") long replyId){
 
         Reply deleteReply = replyService.deleteReply(replyId);
-        ReplyDto.Response response = ReplyMapper.replyToReplyResponseDto(deleteReply);
+        ReplyDto.Response response = mapper.replyToReplyResponseDto(deleteReply);
         return new ResponseEntity(
                 new SingleResponseDto(response), HttpStatus.OK);
     }

--- a/server/src/main/java/com/team_60/Mocco/reply/dto/ReplyDto.java
+++ b/server/src/main/java/com/team_60/Mocco/reply/dto/ReplyDto.java
@@ -1,6 +1,7 @@
 package com.team_60.Mocco.reply.dto;
 
 import com.team_60.Mocco.member.dto.MemberDto;
+import com.team_60.Mocco.reply.entity.Reply;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -30,10 +31,11 @@ public class ReplyDto {
     @Getter
     @Setter
     public static class Response{
-        private long responseId;
+        private long replyId;
         private String content;
         private String createdAt;
         private String modifiedAt;
+        private Reply.ReplyStatus replyStatus;
         private MemberDto.SubResponse member;
     }
 }

--- a/server/src/main/java/com/team_60/Mocco/reply/entity/Reply.java
+++ b/server/src/main/java/com/team_60/Mocco/reply/entity/Reply.java
@@ -26,7 +26,7 @@ public class Reply extends Auditable {
     private Member member;
 
     @ManyToOne
-    @JoinColumn(name = "COMMENT_ID")
+    @JoinColumn(name = "COMMENT_ID", nullable = false)
     private Comment comment;
 
     @Enumerated(value = EnumType.STRING)

--- a/server/src/main/java/com/team_60/Mocco/reply/mapper/ReplyMapper.java
+++ b/server/src/main/java/com/team_60/Mocco/reply/mapper/ReplyMapper.java
@@ -7,6 +7,8 @@ import com.team_60.Mocco.reply.dto.ReplyDto;
 import com.team_60.Mocco.reply.entity.Reply;
 import org.mapstruct.Mapper;
 
+import java.util.List;
+
 @Mapper(componentModel = "spring")
 public interface ReplyMapper {
     default Reply replyPostDtoToReply(ReplyDto.Post dto){
@@ -24,13 +26,6 @@ public interface ReplyMapper {
 
     Reply replyPatchDtoToReply(ReplyDto.Patch dto);
 
-    static ReplyDto.Response replyToReplyResponseDto(Reply reply){
-        return new ReplyDto.Response(
-                reply.getReplyId(),
-                reply.getContent(),
-                reply.getCreatedAt(),
-                reply.getModifiedAt(),
-                MemberMapper.memberToMemberSubResponseDto(reply.getMember())
-        );
-    }
+    ReplyDto.Response replyToReplyResponseDto(Reply reply);
+    List<ReplyDto.Response> repliesToReplyResponseDtos(List<Reply> replies);
 }

--- a/server/src/main/java/com/team_60/Mocco/reply/service/ReplyServiceImpl.java
+++ b/server/src/main/java/com/team_60/Mocco/reply/service/ReplyServiceImpl.java
@@ -52,9 +52,9 @@ public class ReplyServiceImpl implements ReplyService{
     public Reply deleteReply(long replyId) {
         Reply findReply = findVerifiedReply(replyId);
         findReply.setMember(null);
-        findReply.setContent(null);
+        findReply.setContent("");
         findReply.setReplyStatus(Reply.ReplyStatus.REPLY_DELETE);
-        return null;
+        return replyRepository.save(findReply);
     }
 
     private Reply findVerifiedReply(long replyId){

--- a/server/src/main/java/com/team_60/Mocco/study/service/StudyServiceImpl.java
+++ b/server/src/main/java/com/team_60/Mocco/study/service/StudyServiceImpl.java
@@ -8,6 +8,7 @@ import com.team_60.Mocco.member.service.MemberService;
 import com.team_60.Mocco.security.filter.JwtTokenProvider;
 import com.team_60.Mocco.study.entity.Study;
 import com.team_60.Mocco.study.repository.StudyRepository;
+import com.team_60.Mocco.study_member.serive.StudyMemberService;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.*;
@@ -34,6 +35,7 @@ public class StudyServiceImpl implements StudyService{
     private final MemberService memberService;
     private final MemberRepository memberRepository;
     private final JwtTokenProvider jwtTokenProvider;
+    private final StudyMemberService studyMemberService;
 
     @Override
     public Study createStudy(Study study) {
@@ -45,7 +47,7 @@ public class StudyServiceImpl implements StudyService{
 
         //멤버에 스터디 아이디 추가
         member.getStudyLeaderList().add(createdStudy);
-        //memberRepository.save(member);
+        studyMemberService.createStudyMember(createdStudy, member);
         return createdStudy;
 
     }

--- a/server/src/main/resources/application-deploy.yml
+++ b/server/src/main/resources/application-deploy.yml
@@ -11,6 +11,9 @@ spring:
       jdbc:
         time_zone: Asia/Seoul
     show-sql: true
+    properties:
+      hibernate:
+        format_sql: true  # (3) SQL pretty print
 
 mail:
   smtp:

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -9,6 +9,9 @@ spring:
     hibernate:
       ddl-auto: create
     show-sql: true
+    properties:
+      hibernate:
+        format_sql: true  # (3) SQL pretty print
 ---
 spring:
   redis:


### PR DESCRIPTION
<!-- PR Checklist -->

<!-- Reviewers 추가 : FE/BE에 해당하는 파트너 추가 -->
<!-- Assignees 추가 : PR 담당자 (자기 자신) 추가-->
<!-- Labels 추가 : 해당하는 라벨 추가, 없으면 일단 넘어가고, Discord로 간단하게 논의 -->
<!-- Deployment 추가 : 기능에 해당하는 Issue 가 있으면 추가  -->
<!-- PR Title : [Feat]/[Refactor]/[Fix] 중 하나를 선택해서 쓰고, 뒤의 구현/수정 내용을 간결히 작성 -->

## 구현&변경 내용
<!-- 기능 구현일 경우, 구현한 기능을 정리하여 사용 -->
<!-- 리팩토링 or 코드 일부 변경일 경우, 전 후 바뀐 내용 각각 서술 -->

- [Member password 변경 API 구현 완료](https://github.com/codestates-seb/seb39_main_060/commit/d4035a61f6a2f4c09ea649a2a2f26918f003886b)
  - [fix: Member Password API uri, mapper 수정](https://github.com/codestates-seb/seb39_main_060/commit/1f76750ccb7bcaec7bef0979a4d0d568cd756b78)
- [feature: Comment Patch API 수정, Delete API정상 작동을 위해 Entity 수정](https://github.com/codestates-seb/seb39_main_060/commit/8b188292e1ddbfd42365675b5d0cd824e13666d8)
  - Comment Patch API : comment 를 찾은 후에 해당 객체에 반영하고 저장하여야 하는데, 다른 comment를 저장했었음
  - CommentResponseDto 관련 Mapper를 DTO 수정에 용이하도록 수정
- [fix: Study 생성시, 팀장은 Study의 Member로 등록함](https://github.com/codestates-seb/seb39_main_060/commit/c12aa0a453b450e404a6cb8d2d9ef768cd8b72b6)
  - Study 생성시, Study_Member를 생성하도록 추가
- [fix: mapstruct가 자동으로 파일을 만들도록 수정](https://github.com/codestates-seb/seb39_main_060/commit/b35bf64f9279dabf217ce8ac60e700804c18b89c)
  - Mapstruct에 기능을 이용하지 않고, 수동으로 많이 구현하였더니, DTO 수정하기가 매우 불편하여 Mapstruct 자동으로 인식하는 범위를 일부 알아내어 수정함
  - Mapstrust는 다른 Mapper 파일에서 변경하는 함수를 만들고 다른 DTO Column에서 똑같이 변경해야 한다면, 똑같이 변경해줌

- [fix: Reply Delete 관련 API Service 수정, 스터디 신청 거부 API 정상 작동하도록 수정](https://github.com/codestates-seb/seb39_main_060/commit/3913414a76cc72868f32734ed4e2591de7690d53)