### PR TITLE
[Fix] 비로그인시 헤더의 마이페이지 버튼 비활성화

### DIFF
--- a/client/src/components/Common/Header/Header.js
+++ b/client/src/components/Common/Header/Header.js
@@ -141,11 +141,13 @@ function Header() {
             type={'header_skyblue'}
             onClick={handleFindStudyClick}
           />
-          <Button
-            text={'마이 페이지'}
-            type={'header_skyblue'}
-            onClick={handleMyPageClick}
-          />
+          {userInfo ? (
+            <Button
+              text={'마이 페이지'}
+              type={'header_skyblue'}
+              onClick={handleMyPageClick}
+            />
+          ) : null}
         </div>
         {/* 오른쪽 컨테이너 */}
         <div
@@ -178,7 +180,7 @@ function Header() {
                   `}
                 >
                   <img
-                    src="/logo192.png"
+                    src={userInfo.profileImage}
                     alt="프로필사진"
                     css={css`
                       height: 60%;

--- a/client/src/components/Common/Header/ProfileModal.js
+++ b/client/src/components/Common/Header/ProfileModal.js
@@ -71,7 +71,7 @@ function ProfileModal({
           `}
         >
           <img
-            src="/logo192.png"
+            src={userInfo.profileImage}
             alt="프로필사진"
             css={css`
               height: 100%;


### PR DESCRIPTION
- 또한 헤더 프로필 사진 정적에서 자기 이미지 사용하도록 변경

<!-- PR Checklist -->

<!-- Reviewers 추가 : FE/BE에 해당하는 파트너 추가 -->
<!-- Assignees 추가 : PR 담당자 (자기 자신) 추가-->
<!-- Labels 추가 : 해당하는 라벨 추가, 없으면 일단 넘어가고, Discord로 간단하게 논의 -->
<!-- Deployment 추가 : 기능에 해당하는 Issue 가 있으면 추가  -->
<!-- PR Title : [Feat]/[Refactor]/[Fix] 중 하나를 선택해서 쓰고, 뒤의 구현/수정 내용을 간결히 작성 -->

## 구현&변경 내용
<!-- 기능 구현일 경우, 구현한 기능을 정리하여 사용 -->
<!-- 리팩토링 or 코드 일부 변경일 경우, 전 후 바뀐 내용 각각 서술 -->

- 비로그인시 헤더에 존재하는 마이페이지 버튼을 렌더링 안하게끔 수정

## Other information
<!-- 특이사항, 추후 수정할 점, 관련 의논해야 할 내용, -->
<!-- 구현한 기능 기술 블로그, 어렵게 해결한 에러 정리 자료, 등등 -->

- 추가로  헤더의 프로필사진과 레이어팝업의 프로필 사진을 테스트용 정적 파일에서 유저정보의 이미지를 가져오게끔 변경