### PR TITLE
[Fix] myPage: ShortList(4개 미만 스터디리스트 컴포넌트) 오류 해결, Callback 깃헙 연동 시 에러 처리 수정

### DIFF
--- a/client/src/components/PageComponent/Main/MyStudyList/ProgressList.js
+++ b/client/src/components/PageComponent/Main/MyStudyList/ProgressList.js
@@ -67,6 +67,7 @@ function ProgressList() {
   };
 
   const clickHandlerFnc = (studyData) => {
+    console.log('클릭');
     if (
       studyData.studyStatus === 'STUDY_COMPLETE' &&
       studyData.evaluationStatus === 'BEFORE_EVALUATION' &&
@@ -127,7 +128,7 @@ function ProgressList() {
         <ShortListSection
           studyArr={studyArr}
           progress={'propgress'}
-          clickHandler={clickHandlerFnc}
+          clickFunc={clickHandlerFnc}
         />
       ) : (
         <Carousel

--- a/client/src/components/PageComponent/Main/MyStudyList/ShortListSection.js
+++ b/client/src/components/PageComponent/Main/MyStudyList/ShortListSection.js
@@ -29,19 +29,19 @@ const Container = css`
   }
 `;
 
-function ShortListSection(studyArr, progress, done, clickHandler) {
-  console.log(studyArr);
+function ShortListSection(studyArr, progress, done) {
   return (
     <div css={Container}>
       <ul>
         {studyArr &&
           progress &&
           studyArr.studyArr.map((studyData, idx) => (
-            <li key={idx} role="presentation">
-              <StudyCard
-                studyData={studyData}
-                onClick={() => clickHandler(studyData)}
-              />
+            <li
+              key={idx}
+              role="presentation"
+              onClick={() => studyArr.clickFunc(studyData)}
+            >
+              <StudyCard studyData={studyData} />
             </li>
           ))}
         {studyArr &&

--- a/client/src/pages/Callback.js
+++ b/client/src/pages/Callback.js
@@ -94,7 +94,6 @@ function Callback() {
         const response = await request.patch(`/api/members/github-user`, body);
         console.log(response);
         console.log(response.data);
-        navigate(`/main/${memberId}`);
       } catch (err) {
         console.log(err);
         if (
@@ -103,11 +102,11 @@ function Callback() {
             '이 계정의 깃허브를 연동한 유저가 이미 존재합니다.'
         ) {
           alert(err.response.data.message);
-          navigate(-2);
+          navigate(`/main/${memberId}`);
         }
         if (err.response.data.status === 500) {
-          alert(err.response.data.message);
-          navigate(-2);
+          console.log(err.response.data.message);
+          navigate(`/main/${memberId}`);
         }
       }
     }


### PR DESCRIPTION
## 구현&변경 내용
**Shortlist 온클릭 함수 에러 해결**
**깃헙 연동 에러처리**
-500에러가 먼저 나고 성공해서 메인페이지로 돌아가고 있다.
-500에러의 메세지를 alert 해주지 않고 console.log로 처리한다.(수정)
-성공 시 메인페이지로 보내준다(기존 방식대로)

## Other information
깃헙 연동 시 500 에러가 나는 원인을 아직 모름
